### PR TITLE
UI: TF-IDF–LSI preview bar; admin authz consolidation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-mydb}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - TOVA_ADMIN_EMAILS=${TOVA_ADMIN_EMAILS:-}
+      - DJANGO_ADMIN_EMAILS=${DJANGO_ADMIN_EMAILS:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,36 @@
+# Tag version for the builder image
+# Use 'latest' unless you explicitly version your builder image
+VERSION=latest
+
+# Assets image tag
+# Keep this in sync with what your team actually publishes ('latest' or a real version)
+ASSETS_DATE=latest
+
+# Service ports
+API_PORT=8000
+WEB_PORT=8080
+HOST=0.0.0.0
+PORT=5000
+
+# Environment
+ENV=development
+
+OPENAI_API_KEY=""
+
+POSTGRES_USER=tova_user
+POSTGRES_PASSWORD=supersecretpassword
+POSTGRES_DB=tova_db
+
+# App admin allowlist: comma-separated emails. Each gets is_staff + is_superuser + is_admin on login
+# (see web.admin_emails.promote_env_listed_user_to_staff). Effective access also matches staff/superuser
+# and TOVA_ADMIN_EMAILS without DB write — see web.authz.user_has_tova_app_admin_access.
+TOVA_ADMIN_EMAILS=danystevo@gmail.com,juan.fung@nist.gov
+# Legacy alias (used only if TOVA_ADMIN_EMAILS is empty): DJANGO_ADMIN_EMAILS=
+
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_PASSWORD=adminPassword123!
+DJANGO_SUPERUSER_EMAIL=juan.fung@nist.gov
+
+# Django upload size limits (bytes). Increase for larger JSON/JSONL dataset posts.
+DJANGO_DATA_UPLOAD_MAX_MEMORY_SIZE=104857600
+DJANGO_FILE_UPLOAD_MAX_MEMORY_SIZE=104857600

--- a/templates/base.html
+++ b/templates/base.html
@@ -350,7 +350,7 @@
               Trained topic models
             </a>
           </li>
-          {% if user.is_staff %}
+          {% if user.is_staff or request.tova_user.is_admin %}
           <li class="nav-item">
             <a class="nav-link {% if request.resolver_match and request.resolver_match.namespace == 'admin' %}active{% endif %}"
                href="{% url 'admin:index' %}">
@@ -389,7 +389,7 @@
                 {% else %}
                 <div class="tova-account-name">{{ user.email }}</div>
                 {% endif %}
-                {% if user.is_staff %}
+                {% if user.is_staff or request.tova_user.is_admin %}
                 <div class="mt-2"><span class="badge rounded-pill text-bg-primary text-uppercase" style="font-size: 0.65rem; letter-spacing: 0.04em;">Admin</span></div>
                 {% endif %}
               </li>
@@ -412,7 +412,7 @@
                   </span>
                 </button>
               </li>
-              {% if user.is_staff %}
+              {% if user.is_staff or request.tova_user.is_admin %}
               <li>
                 <a class="dropdown-item" href="{% url 'admin:index' %}">
                   <i class="bi bi-shield-lock" aria-hidden="true"></i>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -14,6 +14,18 @@ body {
   flex-direction: column;
 }
 
+  /* Navbar above sticky document table headers (Bootstrap .sticky-top ≈ 1020; dropdown menus ≈ 1000). */
+  nav.navbar {
+    position: relative;
+    z-index: 1030;
+  }
+
+  /* Keep in-page sticky headers below the navbar stacking context */
+  #mainContent thead.sticky-top,
+  #documentsPanel thead.sticky-top {
+    z-index: 2 !important;
+  }
+
 .navbar-brand.navbar-brand--active {
   color: #0d6efd !important;
   font-weight: 800;
@@ -935,7 +947,7 @@ footer {
             <a class="nav-link {% if request.resolver_match and request.resolver_match.url_name == 'trained_models' %}active{% endif %}"
                href="{% url_for 'trained_models' %}">Trained topic models</a>
           </li>
-          {% if user.is_authenticated and user.is_staff %}
+          {% if user.is_authenticated and user.is_staff or user.is_authenticated and request.tova_user.is_admin %}
           <li class="nav-item">
             <a class="nav-link {% if request.resolver_match and request.resolver_match.namespace == 'admin' %}active{% endif %}"
                href="{% url 'admin:index' %}">Admin</a>
@@ -944,9 +956,19 @@ footer {
         </ul>
 
         <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2">
+          {% comment %}Run inference (navbar) — opens #inferenceModal
           <button class="btn btn-primary btn-sm order-1 order-sm-0" type="button" data-bs-toggle="modal" data-bs-target="#inferenceModal">
             <i class="bi bi-lightning-charge-fill me-1"></i>Run inference
           </button>
+          {% endcomment %}
+
+          {% if user.is_authenticated and model_id and corpus_id %}
+          <a class="btn btn-outline-primary btn-sm order-1 order-sm-0 text-nowrap"
+             href="{% url_for 'training_page_get' %}?corpus_id={{ corpus_id|urlencode }}&amp;model_id={{ model_id|urlencode }}&amp;from_models=1&amp;autopreview=1"
+             title="Open the TF-IDF dashboard (fast TF-IDF / k-means preview for this corpus)">
+            <i class="bi bi-lightning-charge-fill me-1" aria-hidden="true"></i>TF-IDF dashboard
+          </a>
+          {% endif %}
 
           {% if user.is_authenticated %}
           <div class="dropdown order-2 order-sm-1">
@@ -999,6 +1021,14 @@ footer {
                   <i class="bi bi-info-circle me-2"></i>Model info
                 </a>
               </li>
+              {% if corpus_id %}
+              <li>
+                <a class="dropdown-item"
+                   href="{% url_for 'training_page_get' %}?corpus_id={{ corpus_id|urlencode }}&amp;model_id={{ model_id|urlencode }}&amp;from_models=1&amp;autopreview=1">
+                  <i class="bi bi-lightning-charge me-2"></i>TF-IDF dashboard <span class="text-muted small">(fast)</span>
+                </a>
+              </li>
+              {% endif %}
               <li>
                 <a class="dropdown-item" href="#" role="button"
                    onclick="event.preventDefault(); window.openSaveSettingsModal && window.openSaveSettingsModal();">

--- a/templates/trained_models.html
+++ b/templates/trained_models.html
@@ -188,7 +188,16 @@
 
     const modelName = m.name || "(unnamed)";
     const corpusName = corpus.name || "Corpus";
+    const corpusIdForPreview = corpus.id || "";
     const createdDate = fmtDate(m.created_at);
+    const tfidfPreviewBtn = corpusIdForPreview
+      ? `<button type="button" class="btn btn-outline-secondary dashboard-btn flex-fill tfidf-preview-btn"
+              data-corpus-id="${escapeHtml(corpusIdForPreview)}"
+              data-model-id="${escapeHtml(m.id)}"
+              title="Open the TF-IDF dashboard (same saved view as during training)">
+           TF-IDF dashboard
+         </button>`
+      : "";
 
     // Details section (hidden by default)
     const detailsHtml = `
@@ -271,10 +280,11 @@
               </button>
             </div>
             
-            <div class="d-flex gap-2 mt-auto pt-3 border-top">
+            <div class="d-flex flex-wrap gap-2 mt-auto pt-3 border-top">
               <button class="btn btn-primary dashboard-btn flex-fill use-model-btn" data-model-id="${escapeHtml(m.id)}">
                 Open Dashboard
               </button>
+              ${tfidfPreviewBtn}
               <button class="btn btn-outline-danger btn-sm delete-model" data-model-id="${escapeHtml(m.id)}" data-model-name="${escapeHtml(modelName)}">
                 Delete
               </button>
@@ -468,6 +478,24 @@
         // GET avoids CSRF on POST (dashboard view accepts model_id via GET or POST).
         const u = new URL("/dashboard", window.location.origin);
         u.searchParams.set("model_id", modelId);
+        window.location.assign(u.toString());
+        return;
+      }
+
+      const tfidfBtn = e.target.closest(".tfidf-preview-btn");
+      if (tfidfBtn) {
+        e.preventDefault();
+        const cid = tfidfBtn.dataset.corpusId;
+        const mid = tfidfBtn.dataset.modelId || "";
+        if (!cid) {
+          alert("Corpus id is missing; TF-IDF preview is unavailable for this row.");
+          return;
+        }
+        const u = new URL("/training/", window.location.origin);
+        u.searchParams.set("corpus_id", cid);
+        if (mid) u.searchParams.set("model_id", mid);
+        u.searchParams.set("from_models", "1");
+        u.searchParams.set("autopreview", "1");
         window.location.assign(u.toString());
         return;
       }

--- a/templates/training.html
+++ b/templates/training.html
@@ -300,7 +300,7 @@
     font-size: 0.78rem;
     line-height: 1.3;
   }
-  .training-page-shell.training--expanded #trainingHeroCard #previewInfo {
+  .training-page-shell.training--expanded .training-focus-center-wrap #previewInfo {
     margin-top: 0.35rem !important;
     margin-bottom: 0 !important;
     font-size: 0.75rem;
@@ -338,6 +338,11 @@
   #trainingCompleteModal.modal {
     z-index: 1075;
   }
+
+  .tfidf-lsi-preview-bar .tfidf-lsi-preview-heading {
+    font-size: clamp(0.95rem, 2.5vw, 1.125rem);
+    line-height: 1.3;
+  }
 </style>
 {% endblock %}
 
@@ -347,12 +352,25 @@
   <div class="training-focus-scrim" id="trainingFocusScrim" aria-hidden="true"></div>
 
   <div class="training-focus-center-wrap" id="trainingFocusCenterWrap">
+    <div id="tfidfLsiPreviewBar" class="tfidf-lsi-preview-bar d-none border-bottom bg-white shadow-sm">
+      <div class="container-fluid py-2 px-3">
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+          <h1 class="tfidf-lsi-preview-heading fw-semibold text-dark min-w-0 mb-0" id="tfidfLsiPreviewBarTitle">
+            <span class="text-break" id="tfidfLsiPreviewModelName"></span><span class="text-muted fw-normal"> · TF-IDF – LSI preview</span>
+          </h1>
+          <div class="d-flex flex-wrap align-items-center gap-2 flex-shrink-0">
+            <a class="btn btn-outline-secondary btn-sm" href="/trained-models">Back to trained models</a>
+            <a class="btn btn-primary btn-sm d-none" id="tfidfOpenModelDashboardBtn" href="#">Open model dashboard</a>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="container-fluid py-3">
       <div class="card shadow-lg border-0 training-hero-card training-status-card" id="trainingHeroCard">
         <div class="card-body p-4">
           <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-1 training-status-top">
             <div>
-              <div class="text-uppercase text-muted xsmall mb-1">Training in progress</div>
+              <div class="text-uppercase text-muted xsmall mb-1" id="trainingStatusKicker">Training in progress</div>
               <div class="d-flex align-items-center gap-2">
                 <span class="pulse-dot" id="trainingDot" aria-hidden="true"></span>
                 <div id="trainingMessage" class="fw-semibold fs-6" aria-live="polite">
@@ -365,7 +383,7 @@
             </small>
           </div>
 
-          <div class="progress mt-3 mb-4 training-progress" role="progressbar" aria-label="Training progress">
+          <div id="trainingProgressWrap" class="progress mt-3 mb-4 training-progress" role="progressbar" aria-label="Training progress">
             <div id="trainingBar"
                  class="progress-bar progress-bar-striped"
                  style="width:0%"
@@ -378,7 +396,7 @@
           <div class="training-hero-summary mb-4 p-3 p-sm-4">
             <div class="d-flex flex-wrap align-items-start justify-content-between gap-2">
               <div class="flex-grow-1 min-w-0">
-                <div class="text-uppercase text-muted xsmall mb-1">Now training</div>
+                <div class="text-uppercase text-muted xsmall mb-1" id="trainingSummaryKicker">Now training</div>
                 <h2 class="hero-title fw-bold mb-2 text-dark text-break" id="transitionDisplayTitle">—</h2>
                 <p class="text-muted small mb-0" id="transitionSubtitle">
                   Linking run to your corpus…
@@ -403,8 +421,14 @@
           </div>
 
           <div class="training-hero-actions">
+            <a id="backToTrainedModelsBtn"
+               class="btn btn-outline-secondary btn-sm d-none"
+               href="/trained-models">Back to trained models</a>
             <button id="openPreviewBtn" class="btn btn-primary btn-sm" type="button">
               Open low-latency preview
+            </button>
+            <button id="toggleTfidfPreviewBtn" class="btn btn-outline-primary btn-sm d-none" type="button">
+              Hide low-latency preview
             </button>
             <div id="redirectButtonContainer" class="ms-sm-auto d-none">
               <button id="goToModelBtn" type="button" class="btn btn-success btn-sm">
@@ -412,9 +436,9 @@
               </button>
             </div>
           </div>
-          <div id="previewInfo" class="small text-danger mt-2 mb-0 d-none"></div>
         </div>
       </div>
+      <div id="previewInfo" class="small text-danger mt-2 mb-0 d-none"></div>
     </div>
   </div>
 
@@ -429,8 +453,8 @@
       <div class="panel" style="flex: 0 0 50%; min-height: 0;">
         <div class="d-flex justify-content-between align-items-center mb-2">
           <h5 class="fw-bold mb-0">Theme Overview</h5>
-          <!-- Optional glossary button (uses existing modal if you have it) -->
           <button type="button"
+                  id="trainingThemeGlossaryBtn"
                   class="btn btn-link btn-sm text-decoration-none"
                   data-bs-toggle="modal"
                   data-bs-target="#topicModelGuideModal">
@@ -663,6 +687,48 @@
   let allDocuments = [];
   let filteredDocs = [];
   let previewLoaded = false;
+  let trainingFromModelsEntry = false;
+
+  const OPEN_PREVIEW_LABEL = "Open low-latency preview";
+  const LOADING_PREVIEW_LABEL = "Loading low-latency preview…";
+  const HIDE_PREVIEW_LABEL = "Hide low-latency preview";
+  const SHOW_PREVIEW_LABEL = "Show low-latency preview";
+  const RETRY_PREVIEW_LABEL = "Try loading low-latency preview";
+
+  /**
+   * Trained-models entry (from_models=1): topic dashboard CTA only. Preview loads
+   * automatically—no Open/Hide controls in the hero.
+   * Active training: Open until data exists, then Hide/Show to collapse the panel.
+   */
+  function syncTrainingHeroPreviewControls() {
+    const openBtn = document.getElementById("openPreviewBtn");
+    const toggleBtn = document.getElementById("toggleTfidfPreviewBtn");
+    const backBtn = document.getElementById("backToTrainedModelsBtn");
+    const mainLayout = document.getElementById("trainingMainLayout");
+    if (!openBtn || !toggleBtn || !backBtn) return;
+
+    if (trainingFromModelsEntry) {
+      backBtn.classList.add("d-none");
+      openBtn.classList.add("d-none");
+      toggleBtn.classList.add("d-none");
+      return;
+    }
+
+    backBtn.classList.add("d-none");
+
+    if (!previewLoaded) {
+      openBtn.classList.remove("d-none");
+      toggleBtn.classList.add("d-none");
+      openBtn.textContent = OPEN_PREVIEW_LABEL;
+      return;
+    }
+
+    const previewPanelVisible = mainLayout && !mainLayout.classList.contains("d-none");
+    openBtn.classList.add("d-none");
+    toggleBtn.classList.remove("d-none");
+    toggleBtn.textContent = previewPanelVisible ? HIDE_PREVIEW_LABEL : SHOW_PREVIEW_LABEL;
+  }
+
   function expandTrainingLayout() {
     const shell = document.getElementById("trainingPageShell");
     if (!shell) return;
@@ -676,6 +742,9 @@
       const corpusId = params.get("corpus_id");
       const jobId    = params.get("job_id");
       const modelId  = params.get("model_id");
+      const fromModels = params.get("from_models") === "1";
+      const autopreview = params.get("autopreview") === "1";
+      trainingFromModelsEntry = fromModels;
       console.log("jobId:", jobId, "modelId:", modelId);
 
       if (!corpusId) {
@@ -684,16 +753,20 @@
       }
 
       wireUI();
-      await enrichTransitionMeta({ corpusId, jobId, modelId });
-      wirePreviewChoice(corpusId);
+      await enrichTransitionMeta({
+        corpusId,
+        jobId: fromModels ? null : jobId,
+        modelId,
+      });
 
-      if (jobId) {
-        startPolling(`/status/jobs/${encodeURIComponent(jobId)}`, 1000);
+      if (fromModels) {
+        await enterStaticPreviewMode({ corpusId, modelId, autopreview, fromModels: true });
       } else {
-        // Optional fallback if you ever land here without job_id
-        // (callTrainingInfo would need to be implemented)
-        // const { statusUrl } = await callTrainingInfo(corpusId);
-        // if (statusUrl) startPolling(statusUrl, 1000);
+        wirePreviewChoice(corpusId);
+        if (jobId) {
+          startPolling(`/status/jobs/${encodeURIComponent(jobId)}`, 1000);
+        }
+        syncTrainingHeroPreviewControls();
       }
     } catch (err) {
       console.error("Error during initialization:", err);
@@ -717,7 +790,7 @@
 
       const docs = Array.isArray(jsonData.documents) ? jsonData.documents : [];
       if (!docs.length) {
-        return { ok: false, reason: "No preview data is available yet. Training is still running." };
+        return { ok: false, reason: "No low-latency preview data yet. Training may still be running." };
       }
       renderThemeVisualizations(docs);
       populateThemeDiagnosticsTable(jsonData.per_cluster || {});
@@ -736,6 +809,98 @@
     }
   }
 
+  async function enterStaticPreviewMode({ corpusId, modelId, autopreview, fromModels = false }) {
+    const titleEl = document.getElementById("transitionDisplayTitle");
+    const modelDisplayName = (titleEl?.textContent || "").trim().replace(/^—$/, "") || "Your topic model";
+
+    expandTrainingLayout();
+
+    const topBar = document.getElementById("tfidfLsiPreviewBar");
+    const topBarName = document.getElementById("tfidfLsiPreviewModelName");
+    const openDash = document.getElementById("tfidfOpenModelDashboardBtn");
+    const heroCard = document.getElementById("trainingHeroCard");
+
+    if (topBar) topBar.classList.remove("d-none");
+    if (topBarName) topBarName.textContent = modelDisplayName;
+    if (openDash) {
+      if (modelId) {
+        const u = new URL("/dashboard", window.location.origin);
+        u.searchParams.set("model_id", modelId);
+        openDash.href = u.toString();
+        openDash.classList.remove("d-none");
+      } else {
+        openDash.removeAttribute("href");
+        openDash.classList.add("d-none");
+      }
+    }
+    if (heroCard) heroCard.classList.add("d-none");
+
+    document.getElementById("trainingThemeGlossaryBtn")?.classList.add("d-none");
+    document.title = `TOVA · ${modelDisplayName} · TF-IDF – LSI preview`;
+
+    document.getElementById("redirectButtonContainer")?.classList.add("d-none");
+
+    wirePreviewChoice(corpusId);
+
+    const shouldAutoLoadPreview = autopreview || fromModels;
+    if (shouldAutoLoadPreview) {
+      const mainLayout = document.getElementById("trainingMainLayout");
+      const previewInfo = document.getElementById("previewInfo");
+      const result = await loadVisualization(corpusId);
+      if (result?.ok) {
+        previewLoaded = true;
+        mainLayout?.classList.remove("d-none");
+      } else if (previewInfo) {
+        const msg =
+          result?.reason ||
+          "No saved low-latency preview found. The draft folder may have been removed, or preview was never generated.";
+        previewInfo.replaceChildren();
+        const line = document.createElement("div");
+        line.className = "text-danger";
+        line.textContent = msg;
+        previewInfo.appendChild(line);
+        if (fromModels) {
+          const retry = document.createElement("button");
+          retry.type = "button";
+          retry.className = "btn btn-sm btn-outline-primary mt-2";
+          retry.textContent = RETRY_PREVIEW_LABEL;
+          retry.addEventListener("click", async () => {
+            retry.disabled = true;
+            const r = await loadVisualization(corpusId);
+            retry.disabled = false;
+            if (r?.ok) {
+              previewLoaded = true;
+              mainLayout?.classList.remove("d-none");
+              previewInfo.classList.add("d-none");
+              previewInfo.replaceChildren();
+            }
+          });
+          previewInfo.appendChild(retry);
+        }
+        previewInfo.classList.remove("d-none");
+      }
+    }
+
+    syncTrainingHeroPreviewControls();
+  }
+
+  function wireTfidfPreviewToggle(mainLayout) {
+    const toggleBtn = document.getElementById("toggleTfidfPreviewBtn");
+    if (!mainLayout || !toggleBtn || trainingFromModelsEntry) {
+      syncTrainingHeroPreviewControls();
+      return;
+    }
+    if (!toggleBtn.dataset.bound) {
+      toggleBtn.dataset.bound = "1";
+      toggleBtn.addEventListener("click", () => {
+        const wasVisible = !mainLayout.classList.contains("d-none");
+        mainLayout.classList.toggle("d-none", wasVisible);
+        syncTrainingHeroPreviewControls();
+      });
+    }
+    syncTrainingHeroPreviewControls();
+  }
+
   function wirePreviewChoice(corpusId) {
     const openBtn = document.getElementById("openPreviewBtn");
     const mainLayout = document.getElementById("trainingMainLayout");
@@ -745,11 +910,12 @@
         expandTrainingLayout();
         if (previewLoaded) {
           mainLayout?.classList.remove("d-none");
+          wireTfidfPreviewToggle(mainLayout);
           return;
         }
         openBtn.disabled = true;
         const oldText = openBtn.textContent;
-        openBtn.textContent = "Loading preview...";
+        openBtn.textContent = LOADING_PREVIEW_LABEL;
         if (previewInfo) {
           previewInfo.classList.add("d-none");
           previewInfo.textContent = "";
@@ -759,19 +925,21 @@
           if (result?.ok) {
             previewLoaded = true;
             mainLayout?.classList.remove("d-none");
+            wireTfidfPreviewToggle(mainLayout);
           } else if (previewInfo) {
-            previewInfo.textContent = result?.reason || "Preview is not available yet.";
+            previewInfo.textContent = result?.reason || "Low-latency preview is not available yet.";
             previewInfo.classList.remove("d-none");
           }
         } catch (e) {
           console.error("Preview load failed:", e);
           if (previewInfo) {
-            previewInfo.textContent = "Preview is not available yet.";
+            previewInfo.textContent = "Low-latency preview is not available yet.";
             previewInfo.classList.remove("d-none");
           }
         } finally {
-          openBtn.textContent = oldText || "Open low-latency preview";
+          openBtn.textContent = oldText || OPEN_PREVIEW_LABEL;
           openBtn.disabled = false;
+          syncTrainingHeroPreviewControls();
         }
       });
       openBtn.dataset.bound = "1";
@@ -968,6 +1136,7 @@
     const detBar      = document.getElementById("trainingBar");
     const indBar      = document.getElementById("indeterminateBar");
     const dot         = document.getElementById("trainingDot");
+    const progressWrap = document.getElementById("trainingProgressWrap");
 
     if (!trainingEl || !etaEl || !activityEl) return;
 
@@ -1045,12 +1214,15 @@
       (status && finishedStatuses.has(String(status).toLowerCase())) ||
       (pct !== null && pct >= 100);
 
+    const hideProgressBar = !!error || isComplete;
+    if (progressWrap) progressWrap.classList.toggle("d-none", hideProgressBar);
+
     if (error) {
       setDotState("err");
       setProgress({ percent: null, running: false });
     } else if (isComplete) {
       setDotState("done");
-      setProgress({ percent: 100, running: true });
+      setProgress({ percent: null, running: false });
     } else {
       setDotState("run");
       setProgress({ percent: pct, running: true });

--- a/ui/web/admin_emails.py
+++ b/ui/web/admin_emails.py
@@ -1,0 +1,50 @@
+"""Resolve admin allowlist from environment (TOVA_ADMIN_EMAILS, legacy DJANGO_ADMIN_EMAILS).
+
+Emails in this list get **effective** app admin access on every request (see ``web.authz``) and,
+on login, are persisted with ``is_staff``, ``is_superuser``, and ``is_admin`` via
+:func:`promote_env_listed_user_to_staff` so Django admin and ``/staff/*`` APIs stay aligned.
+
+The database ``is_admin`` flag alone can also grant access; admins may toggle ``is_admin`` for
+other users via ``/staff/users/<id>/toggle-admin`` subject to "last admin" safeguards.
+"""
+
+from __future__ import annotations
+
+import os
+
+from web.models import User
+
+
+def admin_emails_from_env() -> set[str]:
+    raw = os.getenv("TOVA_ADMIN_EMAILS", "").strip()
+    if not raw:
+        raw = os.getenv("DJANGO_ADMIN_EMAILS", "").strip()
+    if not raw:
+        return set()
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def promote_env_listed_user_to_staff(user: User) -> bool:
+    """If the user's email is in the env admin list, persist staff flags (Django admin access).
+
+    Matches behaviour of ``sync_superuser`` for env-listed accounts. Returns True if the user was updated.
+    """
+    emails = admin_emails_from_env()
+    if not emails or not getattr(user, "email", None):
+        return False
+    if user.email.lower() not in emails:
+        return False
+
+    needs_save = False
+    if not user.is_staff:
+        user.is_staff = True
+        needs_save = True
+    if not user.is_superuser:
+        user.is_superuser = True
+        needs_save = True
+    if not user.is_admin:
+        user.is_admin = True
+        needs_save = True
+    if needs_save:
+        user.save()
+    return needs_save

--- a/ui/web/authz.py
+++ b/ui/web/authz.py
@@ -1,0 +1,63 @@
+"""Application-wide admin / privilege checks (TOVA web UI).
+
+Effective "app admin" is granted if any of the following hold for an authenticated
+:class:`web.models.User`:
+
+- ``user.is_admin`` (database flag; can be toggled by other admins)
+- ``user.is_staff`` or ``user.is_superuser`` (Django admin semantics)
+- Email appears in ``TOVA_ADMIN_EMAILS`` / ``DJANGO_ADMIN_EMAILS`` (env allowlist)
+
+Env-listed users are also promoted on login via
+:func:`web.admin_emails.promote_env_listed_user_to_staff` so privileges persist in the DB.
+
+Django's built-in admin and the TOVA console under ``/admin/tova/`` use
+``@staff_member_required`` / ``is_staff``; this module aligns *session* checks
+(``request.tova_user``) with the same rules so ``/staff/...`` API routes match
+what operators see in the UI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.contrib.auth.models import AnonymousUser
+
+from web.admin_emails import admin_emails_from_env
+from web.models import User
+
+logger = logging.getLogger(__name__)
+
+
+def user_has_tova_app_admin_access(user) -> bool:
+    """Return True if *user* may use TOVA app-level admin features (staff APIs, toggles).
+
+    Anonymous users or non-:class:`User` principals never qualify.
+    """
+    if not user or not user.is_authenticated or isinstance(user, AnonymousUser):
+        return False
+    if not isinstance(user, User):
+        logger.warning("user_has_tova_app_admin_access: expected web.User, got %s", type(user))
+        return False
+    if getattr(user, "is_admin", False):
+        return True
+    if getattr(user, "is_staff", False) or getattr(user, "is_superuser", False):
+        return True
+    email = (getattr(user, "email", None) or "").strip().lower()
+    return bool(email and email in admin_emails_from_env())
+
+
+def get_tova_user_session_dict(request):
+    """Build the dict exposed as ``request.tova_user`` (or ``None`` if not logged in)."""
+    u = getattr(request, "user", None)
+    if not u or isinstance(u, AnonymousUser) or not u.is_authenticated:
+        return None
+    if not isinstance(u, User):
+        logger.warning("request.user is not web.User: %s", type(u))
+        return None
+    is_admin = user_has_tova_app_admin_access(u)
+    return {
+        "id": str(u.pk),
+        "email": u.email,
+        "name": u.name or u.email,
+        "is_admin": is_admin,
+    }

--- a/ui/web/decorators.py
+++ b/ui/web/decorators.py
@@ -1,0 +1,40 @@
+"""View decorators for the TOVA web UI."""
+
+from __future__ import annotations
+
+from functools import wraps
+
+from django.contrib import messages
+from django.http import JsonResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+def require_tova_app_admin(*, json_response: bool = True, forbidden_payload: dict | None = None):
+    """Require ``request.tova_user["is_admin"]`` (see :mod:`web.authz`).
+
+    Use **below** ``@login_required`` so unauthenticated users are handled first::
+
+        @login_required
+        @require_tova_app_admin(json_response=False)
+        def admin_page(request): ...
+
+    :param json_response: If True, return 403 JSON. If False, flash a message and redirect home.
+    :param forbidden_payload: Optional JSON body for 403 responses (default ``{"error": "Forbidden"}``).
+    """
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped(request, *args, **kwargs):
+            tu = getattr(request, "tova_user", None)
+            if not tu or not tu.get("is_admin"):
+                if json_response:
+                    payload = forbidden_payload if forbidden_payload is not None else {"error": "Forbidden"}
+                    return JsonResponse(payload, status=403)
+                messages.error(request, "You do not have access to the admin area.")
+                return redirect(reverse("web:home"))
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped
+
+    return decorator

--- a/ui/web/middleware.py
+++ b/ui/web/middleware.py
@@ -2,43 +2,9 @@
 
 from __future__ import annotations
 
-import logging
-
 from django.utils.functional import SimpleLazyObject
 
-logger = logging.getLogger(__name__)
-
-
-def _get_tova_user(request):
-    from django.contrib.auth.models import AnonymousUser
-
-    from web.models import User
-
-    u = getattr(request, "user", None)
-    if not u or isinstance(u, AnonymousUser) or not u.is_authenticated:
-        return None
-    if not isinstance(u, User):
-        logger.warning("request.user is not web.User: %s", type(u))
-        return None
-    admin_emails = set()
-    raw = __import__("os").environ.get("TOVA_ADMIN_EMAILS", "").strip()
-    if raw:
-        admin_emails = {e.strip().lower() for e in raw.split(",") if e.strip()}
-    # Staff tools are an "admin console" for this app.
-    # Treat Django staff/superuser users as admins too, so `/staff` works
-    # even when `is_admin` was not set on older accounts.
-    is_admin = bool(
-        getattr(u, "is_admin", False)
-        or getattr(u, "is_staff", False)
-        or getattr(u, "is_superuser", False)
-        or (u.email and u.email.lower() in admin_emails)
-    )
-    return {
-        "id": str(u.pk),
-        "email": u.email,
-        "name": u.name or u.email,
-        "is_admin": is_admin,
-    }
+from web.authz import get_tova_user_session_dict
 
 
 class TovaUserMiddleware:
@@ -48,6 +14,6 @@ class TovaUserMiddleware:
     def __call__(self, request):
         match = getattr(request, "resolver_match", None)
         request.endpoint = match.url_name if match else None
-        request.tova_user = SimpleLazyObject(lambda: _get_tova_user(request))
+        request.tova_user = SimpleLazyObject(lambda: get_tova_user_session_dict(request))
         response = self.get_response(request)
         return response

--- a/ui/web/services/runtime.py
+++ b/ui/web/services/runtime.py
@@ -170,10 +170,9 @@ def _cache_set(cache: dict, key, data):
 
 
 def _admin_emails_from_env():
-    raw = os.getenv("TOVA_ADMIN_EMAILS", "").strip()
-    if not raw:
-        return set()
-    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+    from web.admin_emails import admin_emails_from_env
+
+    return admin_emails_from_env()
 
 
 def build_llm_ui_config(config: dict | None = None):

--- a/ui/web/views.py
+++ b/ui/web/views.py
@@ -41,7 +41,9 @@ from tova.core import drafts
 from tova.core import models as models_module
 
 from web import oauth_okta
-from web.middleware import _get_tova_user
+from web.admin_emails import admin_emails_from_env, promote_env_listed_user_to_staff
+from web.authz import get_tova_user_session_dict
+from web.decorators import require_tova_app_admin
 from web.models import AuditLog, ChatMessage, User, UserConfig
 from web.services import runtime as R
 
@@ -84,7 +86,7 @@ def _log_audit(request, action: str, target_type: str = None, target_id: str = N
 
     log = logging.getLogger(__name__)
     try:
-        actor = _get_tova_user(request) or {}
+        actor = get_tova_user_session_dict(request) or {}
         entry = AuditLog(
             actor_id=actor.get("id"),
             action=action,
@@ -181,6 +183,7 @@ def signup(request):
 
         auth_login(request, user)
         _session_permanent(request)
+        promote_env_listed_user_to_staff(user)
 
         messages.success(request, "Account created! Welcome to TOVA.")
         return redirect(reverse("web:home"))
@@ -209,6 +212,7 @@ def login(request):
 
         auth_login(request, user)
         _session_permanent(request)
+        promote_env_listed_user_to_staff(user)
         _log_audit(request, "login", target_type="user", target_id=str(user.pk), details=user.email)
 
         messages.success(request, "Signed in successfully.")
@@ -279,6 +283,7 @@ def auth_okta_callback(request):
 
     auth_login(request, user)
     _session_permanent(request)
+    promote_env_listed_user_to_staff(user)
     _log_audit(request, "login", target_type="user", target_id=str(user.pk), details=user.email)
 
     messages.success(request, "Signed in with Okta.")
@@ -297,26 +302,24 @@ def logout(request):
 # Admin (superuser) page
 # ------------------------------------------------------------------------------
 @login_required
+@require_tova_app_admin(json_response=False)
 def admin_page(request):
-    """Admin page: list users and manage admin status."""
-    tu = _get_tova_user(request)
-    if not tu or not tu.get("is_admin"):
-        messages.error(request, "You do not have access to the admin area.")
-        return redirect(reverse("web:home"))
+    """Admin entry: redirect to the TOVA console inside Django admin."""
     # The legacy Flask-like "staff tools" console is removed from the UI.
     # Instead, surface the corpora + dashboards directly inside Django admin.
     return redirect(reverse("tova_admin_corpora"))
 
 
 @login_required
+@require_tova_app_admin(
+    forbidden_payload={"success": False, "message": "Forbidden"},
+)
 def admin_toggle_user(request, user_id):
     """Toggle is_admin for a user (only admins). Cannot remove your own admin if you're the last admin."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"success": False, "message": "Forbidden"}, status=403)
     target = User.objects.filter(pk=user_id).first()
     if not target:
         return JsonResponse({"success": False, "message": "User not found"}, status=404)
-    admin_emails = R._admin_emails_from_env()
+    admin_emails = admin_emails_from_env()
     db_admin_count = User.objects.filter(is_admin=True).count()
     # If we're demoting ourselves and we're the only DB admin (and not in env list), forbid
     if (
@@ -340,10 +343,11 @@ def admin_toggle_user(request, user_id):
 
 
 @login_required
+@require_tova_app_admin(
+    forbidden_payload={"success": False, "message": "Forbidden"},
+)
 def admin_create_user(request):
     """Create a new user (admin only). JSON: name, email, password."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"success": False, "message": "Forbidden"}, status=403)
     payload = _get_json(request) or {}
     name = (payload.get("name") or "").strip()
     email = (payload.get("email") or "").strip().lower()
@@ -370,10 +374,11 @@ def admin_create_user(request):
 
 
 @login_required
+@require_tova_app_admin(
+    forbidden_payload={"success": False, "message": "Forbidden"},
+)
 def admin_delete_user(request, user_id):
     """Delete a user (admin only). Cannot delete yourself."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"success": False, "message": "Forbidden"}, status=403)
     if user_id == request.tova_user.get("id"):
         return JsonResponse({"success": False, "message": "Cannot delete your own account"}, status=400)
     target = User.objects.filter(pk=user_id).first()
@@ -387,10 +392,9 @@ def admin_delete_user(request, user_id):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_list_corpora(request):
     """List all corpora across all users (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         r = requests.get(f"{R.API}/data/corpora", timeout=15)
         r.raise_for_status()
@@ -412,10 +416,9 @@ def admin_list_corpora(request):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_delete_corpus(request, corpus_id):
     """Delete any corpus (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         r = requests.get(f"{R.API}/data/corpora/{corpus_id}", timeout=10)
         if r.status_code == 404:
@@ -447,10 +450,9 @@ def admin_delete_corpus(request, corpus_id):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_list_models(request):
     """List all models across all users (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         models_drafts = drafts.list_drafts(type=DraftType.model)
     except Exception as e:
@@ -499,10 +501,9 @@ def admin_list_models(request):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_delete_model(request, model_id):
     """Delete any model (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         up = requests.get(f"{R.API}/data/models/{model_id}", timeout=10)
         if up.status_code == 404:
@@ -533,10 +534,9 @@ def admin_delete_model(request, model_id):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_stats(request):
     """System stats (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         r = requests.get(f"{R.API}/data/corpora", timeout=10)
         corpus_count = len(r.json()) if r.ok else None
@@ -558,10 +558,9 @@ def admin_stats(request):
 
 
 @login_required
+@require_tova_app_admin()
 def admin_audit(request):
     """Paginated audit log (admin only)."""
-    if not getattr(request, "tova_user", None) or not request.tova_user.get("is_admin"):
-        return JsonResponse({"error": "Forbidden"}, status=403)
     try:
         page = max(1, int(request.GET.get("page", 1)))
     except (TypeError, ValueError):
@@ -1997,6 +1996,7 @@ def delete_model(request):
 def dashboard(request):
     model_id = request.POST.get("model_id") or request.GET.get("model_id", "")
     model_name = ""
+    corpus_id = ""
     if model_id:
         try:
             up = requests.get(
@@ -2006,10 +2006,17 @@ def dashboard(request):
             if up.ok:
                 body = up.json() or {}
                 model_name = (body.get("name") or "").strip()
+                meta = body.get("metadata") or {}
                 if not model_name:
-                    meta = body.get("metadata") or {}
                     tr = meta.get("tr_params") or {}
                     model_name = (tr.get("model_name") or "").strip()
+                corpus_id = (body.get("corpus_id") or "").strip()
+                if not corpus_id:
+                    tr = meta.get("tr_params") or {}
+                    corpus_id = (
+                        (meta.get("corpus_id") or "").strip()
+                        or (tr.get("corpus_id") or "").strip()
+                    )
         except requests.RequestException:
             logger.warning(
                 "dashboard: could not fetch model metadata for %s",
@@ -2020,7 +2027,11 @@ def dashboard(request):
         return render(
             request,
             "dashboard.html",
-            {"model_id": model_id, "model_name": model_name},
+            {
+                "model_id": model_id,
+                "model_name": model_name,
+                "corpus_id": corpus_id,
+            },
         )
     except Exception:
         logger.exception(


### PR DESCRIPTION
- Training preview (from_models): single top bar with model name + TF-IDF–LSI preview; back to trained models + open model dashboard; hide hero and glossary in this flow; hide progress when complete.
- Dashboard / trained models: prominent TF-IDF dashboard link and aligned labels.
- Add web.authz (effective app admin), web.decorators.require_tova_app_admin, web.admin_emails; middleware uses get_tova_user_session_dict; staff routes use decorator.
- sample.env: admin allowlist docs (restored on frontend branch). docker-compose, runtime, base template updates.

Made-with: Cursor